### PR TITLE
Set Slack action webhook-type in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: Post to a Slack channel
         id: slack
-        uses: slackapi/slack-github-action@v3
+        uses: slackapi/slack-github-action@v1
         with:
           payload: |
             {

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,7 @@ jobs:
         id: slack
         uses: slackapi/slack-github-action@v3
         with:
+          webhook-type: incoming-webhook
           payload: |
             {
             "text": "New release ${{github.ref_name}} for ${{github.event.repository.name}}.",

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: Post to a Slack channel
         id: slack
-        uses: slackapi/slack-github-action@v1
+        uses: slackapi/slack-github-action@v3
         with:
           webhook-type: incoming-webhook
           payload: |


### PR DESCRIPTION
## What

Adds the required `webhook-type: incoming-webhook` parameter to the `slackapi/slack-github-action` step in `.github/workflows/publish.yml`.

## Why

The Slack GitHub Action requires `webhook-type` to be set explicitly when posting a release notification via an incoming webhook. Without it, the publish workflow's Slack notification step fails.

## Changes

- `.github/workflows/publish.yml`: add `webhook-type: incoming-webhook` to the Slack notification step.
